### PR TITLE
refactor(links): push full link instead of key and target seperately

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datalink"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [features]

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use crate::{
-    link_builder::{LinkBuilder, LinkBuilderError},
+    links::{LinkError, Links},
     value::ValueBuiler,
 };
 
@@ -33,23 +33,24 @@ pub trait Data {
     #[inline]
     fn provide_value<'d>(&'d self, builder: &mut dyn ValueBuiler<'d>) {}
 
+    #[allow(unused_variables)]
     #[inline]
-    fn provide_links(&self, builder: &mut dyn LinkBuilder) -> Result<(), LinkBuilderError> {
-        builder.end()
+    fn provide_links(&self, links: &mut dyn Links) -> Result<(), LinkError> {
+        Ok(())
     }
 
     #[allow(unused_variables)]
     #[inline]
     fn query_links(
         &self,
-        builder: &mut dyn LinkBuilder,
+        links: &mut dyn Links,
         query: &crate::query::Query,
-    ) -> Result<(), LinkBuilderError> {
+    ) -> Result<(), LinkError> {
         use crate::query::LinkSelector;
         match query.selector() {
-            LinkSelector::None => builder.end(),
-            LinkSelector::Any => self.provide_links(builder),
-            _ => Err(LinkBuilderError::UnsupportedQuery),
+            LinkSelector::None => Ok(()),
+            LinkSelector::Any => self.provide_links(links),
+            _ => Err(LinkError::UnsupportedQuery),
         }
     }
 

--- a/src/data/constant.rs
+++ b/src/data/constant.rs
@@ -1,7 +1,7 @@
 use crate::data::unique::Unique;
 use crate::data::{format, Data, DataExt};
 use crate::id::ID;
-use crate::link_builder::{LinkBuilder, LinkBuilderError as LBE};
+use crate::links::{LinkError, Links};
 use crate::value::ValueBuiler;
 
 /// Wrapper for data with compile-time constant ID
@@ -74,17 +74,17 @@ impl<const I: u128, D: Data + ?Sized> Data for Const<I, D> {
     }
 
     #[inline]
-    fn provide_links(&self, builder: &mut dyn LinkBuilder) -> Result<(), LBE> {
-        self.0.provide_links(builder)
+    fn provide_links(&self, links: &mut dyn Links) -> Result<(), LinkError> {
+        self.0.provide_links(links)
     }
 
     #[inline]
     fn query_links(
         &self,
-        builder: &mut dyn LinkBuilder,
+        links: &mut dyn Links,
         query: &crate::query::Query,
-    ) -> Result<(), LBE> {
-        self.0.query_links(builder, query)
+    ) -> Result<(), LinkError> {
+        self.0.query_links(links, query)
     }
 
     #[inline(always)]

--- a/src/data/impls.rs
+++ b/src/data/impls.rs
@@ -1,6 +1,6 @@
 use crate::data::Data;
 use crate::id::ID;
-use crate::link_builder::{LinkBuilder, LinkBuilderError as LBE};
+use crate::links::{LinkError, Links};
 use crate::value::ValueBuiler;
 
 mod core;
@@ -18,16 +18,16 @@ impl Data for &dyn Data {
         (**self).provide_value(builder)
     }
     #[inline]
-    fn provide_links(&self, builder: &mut dyn LinkBuilder) -> Result<(), LBE> {
-        (**self).provide_links(builder)
+    fn provide_links(&self, links: &mut dyn Links) -> Result<(), LinkError> {
+        (**self).provide_links(links)
     }
     #[inline]
     fn query_links(
         &self,
-        builder: &mut dyn LinkBuilder,
+        links: &mut dyn Links,
         query: &crate::query::Query,
-    ) -> Result<(), LBE> {
-        (**self).query_links(builder, query)
+    ) -> Result<(), LinkError> {
+        (**self).query_links(links, query)
     }
     #[inline]
     fn get_id(&self) -> Option<ID> {
@@ -42,16 +42,16 @@ impl<D: Data + ?Sized> Data for Box<D> {
         (**self).provide_value(builder)
     }
     #[inline]
-    fn provide_links(&self, builder: &mut dyn LinkBuilder) -> Result<(), LBE> {
-        (**self).provide_links(builder)
+    fn provide_links(&self, links: &mut dyn Links) -> Result<(), LinkError> {
+        (**self).provide_links(links)
     }
     #[inline]
     fn query_links(
         &self,
-        builder: &mut dyn LinkBuilder,
+        links: &mut dyn Links,
         query: &crate::query::Query,
-    ) -> Result<(), LBE> {
-        (**self).query_links(builder, query)
+    ) -> Result<(), LinkError> {
+        (**self).query_links(links, query)
     }
     #[inline]
     fn get_id(&self) -> Option<ID> {

--- a/src/data/impls/core.rs
+++ b/src/data/impls/core.rs
@@ -1,5 +1,5 @@
 use crate::data::Data;
-use crate::link_builder::{LinkBuilder, LinkBuilderError as LBE};
+use crate::links::{LinkError, Links};
 use crate::value::ValueBuiler;
 
 impl Data for () {}
@@ -198,6 +198,7 @@ mod num {
     }
 }
 
+#[warn(clippy::missing_trait_methods)]
 impl<D: Data> Data for Option<D> {
     #[inline]
     fn provide_value<'d>(&'d self, value: &mut dyn ValueBuiler<'d>) {
@@ -208,10 +209,30 @@ impl<D: Data> Data for Option<D> {
     }
 
     #[inline]
-    fn provide_links(&self, builder: &mut dyn LinkBuilder) -> Result<(), LBE> {
+    fn provide_links(&self, links: &mut dyn Links) -> Result<(), LinkError> {
         match self {
-            Some(data) => data.provide_links(builder),
-            None => builder.end(),
+            Some(data) => data.provide_links(links),
+            None => Ok(()),
+        }
+    }
+
+    #[inline]
+    fn query_links(
+        &self,
+        links: &mut dyn Links,
+        query: &crate::query::Query,
+    ) -> Result<(), LinkError> {
+        match self {
+            Some(data) => data.query_links(links, query),
+            None => Ok(()),
+        }
+    }
+
+    #[inline]
+    fn get_id(&self) -> Option<crate::id::ID> {
+        match self {
+            Some(d) => d.get_id(),
+            None => None,
         }
     }
 }

--- a/src/data/impls/json.rs
+++ b/src/data/impls/json.rs
@@ -2,7 +2,7 @@ use serde_json::{Map, Number, Value as Val};
 
 use crate::data::Data;
 use crate::id::ID;
-use crate::link_builder::{LinkBuilder, LinkBuilderError as LBE, LinkBuilderExt};
+use crate::links::{LinkError, Links, LinksExt};
 use crate::value::ValueBuiler;
 
 impl Data for Val {
@@ -23,11 +23,11 @@ impl Data for Val {
     }
 
     #[inline]
-    fn provide_links(&self, builder: &mut dyn LinkBuilder) -> Result<(), LBE> {
+    fn provide_links(&self, links: &mut dyn Links) -> Result<(), LinkError> {
         match self {
-            Val::Array(v) => v.provide_links(builder),
-            Val::Object(m) => m.provide_links(builder),
-            _ => builder.end(),
+            Val::Array(v) => v.provide_links(links),
+            Val::Object(m) => m.provide_links(links),
+            _ => Ok(()),
         }
     }
 
@@ -42,8 +42,8 @@ impl Data for Val {
 
 impl Data for Map<String, Val> {
     #[inline]
-    fn provide_links(&self, builder: &mut dyn LinkBuilder) -> Result<(), LBE> {
-        builder.extend(self.iter().map(|(k, v)| (k.to_owned(), v.to_owned())))
+    fn provide_links(&self, links: &mut dyn Links) -> Result<(), LinkError> {
+        links.extend(self.iter().map(|(k, v)| (k.to_owned(), v.to_owned())))
     }
 }
 

--- a/src/data/impls/toml.rs
+++ b/src/data/impls/toml.rs
@@ -1,7 +1,7 @@
 use ::toml::{Table, Value as Val};
 
 use crate::data::Data;
-use crate::link_builder::{LinkBuilder, LinkBuilderError as LBE, LinkBuilderExt};
+use crate::links::{LinkError, Links, LinksExt};
 use crate::value::ValueBuiler;
 
 impl Data for Val {
@@ -18,19 +18,18 @@ impl Data for Val {
     }
 
     #[inline]
-    fn provide_links(&self, builder: &mut dyn LinkBuilder) -> Result<(), LBE> {
+    fn provide_links(&self, links: &mut dyn Links) -> Result<(), LinkError> {
         match self {
-            Val::Table(table) => table.provide_links(builder),
-            Val::Array(array) => array.provide_links(builder),
-            _ => builder.end(),
+            Val::Table(table) => table.provide_links(links),
+            Val::Array(array) => array.provide_links(links),
+            _ => Ok(()),
         }
     }
 }
 
 impl Data for Table {
     #[inline]
-    fn provide_links(&self, builder: &mut dyn LinkBuilder) -> Result<(), LBE> {
-        builder.extend(self.iter().map(|(k, v)| (k.to_owned(), v.to_owned())))?;
-        builder.end()
+    fn provide_links(&self, links: &mut dyn Links) -> Result<(), LinkError> {
+        links.extend(self.iter().map(|(k, v)| (k.to_owned(), v.to_owned())))
     }
 }

--- a/src/data/unique.rs
+++ b/src/data/unique.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use crate::data::{format, Data, DataExt};
 use crate::id::ID;
-use crate::link_builder::{LinkBuilder, LinkBuilderError as LBE};
+use crate::links::{LinkError, Links};
 use crate::value::ValueBuiler;
 
 #[derive(Debug, thiserror::Error)]
@@ -95,16 +95,16 @@ impl<D: Data + ?Sized, T: Borrow<D>> Data for AlwaysUnique<D, T> {
         self.as_ref().provide_value(builder)
     }
     #[inline]
-    fn provide_links(&self, builder: &mut dyn LinkBuilder) -> Result<(), LBE> {
-        self.as_ref().provide_links(builder)
+    fn provide_links(&self, links: &mut dyn Links) -> Result<(), LinkError> {
+        self.as_ref().provide_links(links)
     }
     #[inline]
     fn query_links(
         &self,
-        builder: &mut dyn LinkBuilder,
+        links: &mut dyn Links,
         query: &crate::query::Query,
-    ) -> Result<(), LBE> {
-        self.as_ref().query_links(builder, query)
+    ) -> Result<(), LinkError> {
+        self.as_ref().query_links(links, query)
     }
     #[inline]
     fn get_id(&self) -> Option<ID> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 pub mod data;
-pub mod link_builder;
+pub mod links;
 pub mod query;
 pub mod value;
 #[cfg(feature = "well_known")]

--- a/src/query.rs
+++ b/src/query.rs
@@ -2,7 +2,7 @@ mod selectors;
 pub use selectors::*;
 
 use crate::data::BoxedData;
-use crate::link_builder::Link;
+use crate::links::Link;
 
 pub mod prelude {
     pub use super::DataSelector as Data;

--- a/src/query/selectors.rs
+++ b/src/query/selectors.rs
@@ -1,4 +1,4 @@
-use crate::{data::Data, id::ID, link_builder::Link};
+use crate::{data::Data, id::ID, links::Link};
 use std::ops::{BitAnd, BitOr, Not};
 
 pub trait Selector<On: ?Sized> {


### PR DESCRIPTION
This allows implementing Links for much simpler types because the key and target don't have to be stored between calls to push