### PR TITLE
refactor(format): more compact and efficient formatting

### DIFF
--- a/src/data/ext.rs
+++ b/src/data/ext.rs
@@ -224,7 +224,7 @@ pub trait DataExt: Data {
     #[allow(unused_variables)]
     #[inline]
     #[must_use]
-    fn format<F: format::DataFormatter>(&self) -> format::FormattableData<F, Self> {
+    fn format<F: format::Format>(&self) -> format::FormattableData<F, Self> {
         self.into()
     }
 }

--- a/src/data/format.rs
+++ b/src/data/format.rs
@@ -4,18 +4,26 @@ use std::{
     marker::PhantomData,
 };
 
-use crate::data::{BoxedData, Data};
 use crate::links::{Links, Result, CONTINUE};
 use crate::value::ValueBuiler;
+use crate::{
+    data::{BoxedData, Data},
+    links::Link,
+};
 
 #[derive(Default, Debug)]
-pub struct FORMAT<const SERIAL: bool = false, const MAX_DEPTH: u16 = 6, const COMPACT: bool = false>;
+pub struct FORMAT<const SERIAL: bool = false, const MAX_DEPTH: u16 = 6, const VERBOSITY: i8 = 0>;
 
-pub type COMPACT<const MAX_DEPTH: u16 = 6> = FORMAT<true, MAX_DEPTH, true>;
-pub type DEBUG = FORMAT<true, 6, false>;
+pub type COMPACT<const MAX_DEPTH: u16 = 6> = FORMAT<true, MAX_DEPTH, -1>;
+pub type DEBUG = FORMAT<true, 6, 1>;
 
-pub trait DataFormatter {
+pub trait Format {
     type State: Default + Copy;
+
+    #[inline]
+    fn verbosity() -> i8 {
+        0
+    }
 
     #[inline]
     #[must_use]
@@ -29,181 +37,157 @@ pub trait DataFormatter {
         data: &(impl Data + ?Sized),
         state: Self::State,
     ) -> fmt::Result {
-        let mut d = Self::create_debug_struct(f, data, state);
+        // Format prefix
+        Self::fmt_prefix(f, data)?;
+
+        if Self::verbosity() < 0 {
+            let values = crate::value::Value::from_data(data);
+            if let Some(val) = values.as_enum() {
+                let mut has_links = None::<BoxedData>;
+                // Ignore errors
+                let _ = data.provide_links(&mut has_links);
+                if has_links.is_none() {
+                    if let Some(v) = val {
+                        f.write_fmt(format_args!("({v})"))?;
+                    } else {
+                        f.write_str("")?;
+                    }
+                    return Ok(());
+                }
+            }
+        }
+
+        let mut set = f.debug_set();
 
         // Format values
-        Self::fmt_values(&mut d, data, state);
+        Self::fmt_values_into_set(&mut set, data, state);
 
         // Format links
-        Self::fmt_links(&mut d, data, state);
+        Self::fmt_links_into_set(&mut set, data, state);
 
-        d.finish()
-    }
+        // Finish set
+        set.finish()?;
 
-    #[allow(unused_variables)]
-    #[inline]
-    fn fmt_values(
-        f: &mut fmt::DebugStruct<'_, '_>,
-        data: &(impl Data + ?Sized),
-        state: Self::State,
-    ) {
-        data.provide_value(f);
-    }
-
-    #[allow(unused_variables)]
-    #[inline]
-    fn fmt_links(
-        f: &mut fmt::DebugStruct<'_, '_>,
-        data: &(impl Data + ?Sized),
-        state: Self::State,
-    ) {
-        f.field("links", &format_args!("..."));
+        // Format suffix
+        Self::fmt_suffix(f, data)?;
+        Ok(())
     }
 
     #[inline]
-    fn fmt_link(
-        f: &mut fmt::Formatter<'_>,
-        key: Option<&(impl Data + ?Sized)>,
-        target: &(impl Data + ?Sized),
-        state: Self::State,
-    ) -> fmt::Result {
-        if let Some(key) = key {
-            Self::fmt(f, key, state)?;
-            f.write_str(" -> ")?;
+    fn fmt_prefix(f: &mut fmt::Formatter<'_>, data: &(impl Data + ?Sized)) -> fmt::Result {
+        if Self::verbosity() <= -2 {
+            f.write_str("D")?;
         } else {
-            f.write_str("- ")?;
+            f.write_str("Data")?;
         }
-        Self::fmt(f, target, state)?;
+
+        #[cfg(feature = "unique")]
+        if Self::verbosity() > 0 {
+            if let Some(id) = data.get_id() {
+                f.write_fmt(format_args!("[{id}]"))?;
+            }
+        }
 
         Ok(())
     }
 
     #[allow(unused_variables)]
     #[inline]
-    fn create_debug_struct<'a, 'b>(
+    fn fmt_suffix(f: &mut fmt::Formatter<'_>, data: &(impl Data + ?Sized)) -> fmt::Result {
+        Ok(())
+    }
+
+    #[inline]
+    fn fmt_link<'a, 'b, L: Link>(
         f: &'a mut fmt::Formatter<'b>,
-        data: &(impl Data + ?Sized),
-        state: Self::State,
-    ) -> fmt::DebugStruct<'a, 'b> {
-        #[cfg(feature = "unique")]
-        if let Some(id) = data.get_id() {
-            return f.debug_struct(&format!("Data[{id}]"));
-        }
-
-        f.debug_struct("Data")
-    }
-}
-
-impl<const SERIAL: bool, const MAX_DEPTH: u16> DataFormatter for FORMAT<SERIAL, MAX_DEPTH, false> {
-    type State = u16;
-
-    #[inline]
-    fn init_state() -> Self::State {
-        MAX_DEPTH
-    }
-
-    #[inline]
-    fn fmt_links(
-        f: &mut fmt::DebugStruct<'_, '_>,
-        data: &(impl Data + ?Sized),
-        state: Self::State,
-    ) {
-        if MAX_DEPTH == 0 || state == 0 {
-            f.field("links", &format_args!("..."));
-            return;
-        }
-
-        if SERIAL {
-            let links = serial::SerialLinks::<Self, _>::new(data, state.saturating_sub(1));
-            if !links.is_empty() {
-                f.field("links", &links);
-            }
-            return;
-        }
-
-        let links = recursive::RecursiveFmt::<Self, _>::new(data, state.saturating_sub(1));
-        f.field("links", &links);
-    }
-}
-
-impl<const SERIAL: bool, const MAX_DEPTH: u16> DataFormatter for FORMAT<SERIAL, MAX_DEPTH, true> {
-    type State = u16;
-
-    #[inline]
-    fn init_state() -> Self::State {
-        MAX_DEPTH
-    }
-
-    #[inline]
-    fn fmt(
-        f: &mut fmt::Formatter<'_>,
-        data: &(impl Data + ?Sized),
+        link: &L,
         state: Self::State,
     ) -> fmt::Result {
-        let values = crate::value::Value::from_data(data);
-        let links = serial::SerialLinks::<Self, _>::new(data, state.saturating_sub(1));
-
-        if links.is_empty() {
-            match values.as_enum() {
-                Some(None) => {
-                    f.write_str("Data")?;
-                    return Ok(());
-                }
-                Some(Some(v)) => {
-                    f.write_fmt(format_args!("Data({v})"))?;
-                    return Ok(());
-                }
-                None => {}
-            }
-        }
-
-        let mut d = f.debug_struct("Data");
-
-        // Format values
-        Self::fmt_values(&mut d, &values, state);
-
-        // Format links
-        if links.is_empty() {
-            // no links
-        } else if MAX_DEPTH == 0 || state == 0 {
-            d.field("links", &format_args!("..."));
+        if let Some(key) = link.key() {
+            Self::fmt(f, key, state)?;
+            f.write_str(" -> ")?;
         } else {
-            d.field("links", &links);
+            f.write_str("- ")?;
         }
+        Self::fmt(f, link.target(), state)
+    }
 
-        d.finish()
+    #[allow(unused_variables)]
+    #[inline]
+    fn fmt_values_into_set<'a, 'b>(
+        set: &mut fmt::DebugSet<'a, 'b>,
+        data: &(impl Data + ?Sized),
+        state: Self::State,
+    ) {
+        data.provide_value(set);
+    }
+
+    #[allow(unused_variables)]
+    #[inline]
+    fn fmt_links_into_set<'a, 'b>(
+        set: &mut fmt::DebugSet<'a, 'b>,
+        data: &(impl Data + ?Sized),
+        state: Self::State,
+    ) {
+        set.entry(&format_args!("..."));
+    }
+}
+
+impl<const SERIAL: bool, const MAX_DEPTH: u16, const VERBOSITY: i8> Format
+    for FORMAT<SERIAL, MAX_DEPTH, VERBOSITY>
+{
+    type State = u16;
+
+    #[inline]
+    fn verbosity() -> i8 {
+        VERBOSITY
     }
 
     #[inline]
-    fn fmt_links(
-        f: &mut fmt::DebugStruct<'_, '_>,
+    fn init_state() -> Self::State {
+        MAX_DEPTH
+    }
+
+    #[inline]
+    fn fmt_links_into_set<'a, 'b>(
+        set: &mut fmt::DebugSet<'a, 'b>,
         data: &(impl Data + ?Sized),
         state: Self::State,
     ) {
         if MAX_DEPTH == 0 || state == 0 {
-            f.field("links", &format_args!("..."));
+            set.entry(&format_args!("..."));
             return;
         }
 
         if SERIAL {
-            let links = serial::SerialLinks::<Self, _>::new(data, state - 1);
-            if !links.is_empty() {
-                f.field("links", &links);
-            }
-            return;
+            let mut links = Vec::<(Option<BoxedData>, BoxedData)>::new();
+            // Ignore errors
+            let _ = data.provide_links(&mut links);
+            let inner_state = state.saturating_sub(1);
+            set.entries(links.into_iter().map(|(key, target)| {
+                let link = LinkEntry::<_, Self> {
+                    link: (key, target),
+                    state: inner_state,
+                };
+                link
+            }));
+        } else {
+            let mut links = StreamingLinks::<'_, '_, '_, Self> {
+                fmt_set: set,
+                state: state.saturating_sub(1),
+            };
+            // Ignore errors
+            let _ = data.provide_links(&mut links);
         }
-
-        let links = recursive::RecursiveFmt::<Self, _>::new(data, state - 1);
-        f.field("links", &links);
     }
 }
 
-pub struct FormattableData<'d, F: DataFormatter, D: Data + ?Sized> {
+pub struct FormattableData<'d, F: Format, D: Data + ?Sized> {
     data: &'d D,
     phantom: PhantomData<F>,
 }
 
-impl<'d, F: DataFormatter, D: Data + ?Sized> From<&'d D> for FormattableData<'d, F, D> {
+impl<'d, F: Format, D: Data + ?Sized> From<&'d D> for FormattableData<'d, F, D> {
     #[inline]
     fn from(data: &'d D) -> Self {
         Self {
@@ -213,201 +197,115 @@ impl<'d, F: DataFormatter, D: Data + ?Sized> From<&'d D> for FormattableData<'d,
     }
 }
 
-impl<F: DataFormatter, D: Data + ?Sized> Display for FormattableData<'_, F, D> {
+impl<F: Format, D: Data + ?Sized> Display for FormattableData<'_, F, D> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         F::fmt(f, self.data, F::init_state())
     }
 }
 
-impl<F: DataFormatter, D: Data + ?Sized> Debug for FormattableData<'_, F, D> {
+impl<F: Format, D: Data + ?Sized> Debug for FormattableData<'_, F, D> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         F::fmt(f, self.data, F::init_state())
     }
 }
 
-struct FormattableLink<F: DataFormatter, K: Data, T: Data> {
-    key: Option<K>,
-    target: T,
+struct LinkEntry<L, F: Format + ?Sized> {
+    link: L,
     state: F::State,
-    phantom: PhantomData<F>,
 }
 
-impl<F: DataFormatter, K: Data, T: Data> Debug for FormattableLink<F, K, T> {
+impl<L: Link, F: Format + ?Sized> Debug for LinkEntry<L, F> {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        F::fmt_link(f, self.key.as_ref(), &self.target, self.state)
+        F::fmt_link(f, &self.link, self.state)
     }
 }
 
-mod recursive {
-    use super::*;
+struct StreamingLinks<'a, 'b, 'c, F: Format> {
+    fmt_set: &'a mut fmt::DebugSet<'b, 'c>,
+    state: F::State,
+}
 
-    pub(super) struct RecursiveFmt<'d, F: DataFormatter, D: Data + ?Sized> {
-        data: &'d D,
-        state: F::State,
-        phantom: PhantomData<F>,
-    }
+impl<F: Format> Links for StreamingLinks<'_, '_, '_, F> {
+    fn push(&mut self, target: BoxedData, key: Option<BoxedData>) -> Result {
+        let link = LinkEntry::<_, F> {
+            link: (key, target),
+            state: self.state,
+        };
+        self.fmt_set.entry(&link);
 
-    impl<'d, F: DataFormatter, D: Data + ?Sized> RecursiveFmt<'d, F, D> {
-        #[inline]
-        pub(super) fn new(data: &'d D, state: F::State) -> Self {
-            Self {
-                data,
-                state,
-                phantom: PhantomData,
-            }
-        }
-    }
-
-    impl<'d, F: DataFormatter, D: Data + ?Sized> Debug for RecursiveFmt<'d, F, D> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            let fmt_set = f.debug_set();
-            let mut links = RecursiveLinks::<F> {
-                fmt_set,
-                state: self.state,
-                phantom: PhantomData,
-            };
-            self.data
-                .provide_links(&mut links)
-                .map_err(|_| std::fmt::Error)?;
-            Ok(())
-        }
-    }
-
-    struct RecursiveLinks<'a, 'b, F: DataFormatter> {
-        fmt_set: fmt::DebugSet<'a, 'b>,
-        state: F::State,
-        phantom: PhantomData<F>,
-    }
-
-    impl<F: DataFormatter> Links for RecursiveLinks<'_, '_, F> {
-        fn push(&mut self, target: BoxedData, key: Option<BoxedData>) -> Result {
-            let link = FormattableLink::<F, _, _> {
-                key,
-                target,
-                state: self.state,
-                phantom: PhantomData,
-            };
-            self.fmt_set.entry(&link);
-
-            CONTINUE
-        }
+        CONTINUE
     }
 }
 
-mod serial {
-
-    use super::*;
-
-    pub(super) struct SerialLinks<'d, F: DataFormatter, D: Data + ?Sized> {
-        state: F::State,
-        links: Vec<(Option<BoxedData>, BoxedData)>,
-        formatter: PhantomData<F>,
-        data: PhantomData<&'d D>,
-    }
-
-    impl<'d, F: DataFormatter, D: Data + ?Sized> SerialLinks<'d, F, D> {
-        #[inline]
-        pub(super) fn new(data: &'d D, state: F::State) -> Self {
-            let mut links = Vec::<(Option<BoxedData>, BoxedData)>::new();
-            // TODO: do something about an error here
-            let _ = data.provide_links(&mut links);
-            Self {
-                state,
-                links,
-                formatter: PhantomData,
-                data: PhantomData,
-            }
-        }
-
-        #[inline]
-        pub(super) fn is_empty(&self) -> bool {
-            self.links.is_empty()
-        }
-    }
-
-    impl<'d, F: DataFormatter, D: Data + ?Sized> Debug for SerialLinks<'d, F, D> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            let mut fmt_set = f.debug_set();
-            for (k, t) in &self.links {
-                let link = FormattableLink::<F, _, _> {
-                    key: k.as_ref().map(|k| &**k),
-                    target: t.as_ref(),
-                    state: self.state,
-                    phantom: PhantomData,
-                };
-                fmt_set.entry(&link);
-            }
-            fmt_set.finish()
-        }
-    }
-}
-
-#[warn(clippy::missing_trait_methods)]
-impl ValueBuiler<'_> for fmt::DebugStruct<'_, '_> {
+impl ValueBuiler<'_> for fmt::DebugSet<'_, '_> {
     #[inline]
     fn bool(&mut self, value: bool) {
-        self.field("bool", &value);
+        match value {
+            true => self.entry(&"bool: true"),
+            false => self.entry(&"bool: false"),
+        };
     }
     #[inline]
     fn u8(&mut self, value: u8) {
-        self.field("u8", &value);
+        self.entry(&format_args!("u8: {}", value));
     }
     #[inline]
     fn i8(&mut self, value: i8) {
-        self.field("i8", &value);
+        self.entry(&format_args!("i8: {}", value));
     }
     #[inline]
     fn u16(&mut self, value: u16) {
-        self.field("u16", &value);
+        self.entry(&format_args!("u16: {}", value));
     }
     #[inline]
     fn i16(&mut self, value: i16) {
-        self.field("i16", &value);
+        self.entry(&format_args!("i16: {}", value));
     }
     #[inline]
     fn u32(&mut self, value: u32) {
-        self.field("u32", &value);
+        self.entry(&format_args!("u32: {}", value));
     }
     #[inline]
     fn i32(&mut self, value: i32) {
-        self.field("i32", &value);
+        self.entry(&format_args!("i32: {}", value));
     }
     #[inline]
     fn u64(&mut self, value: u64) {
-        self.field("u64", &value);
+        self.entry(&format_args!("u64: {}", value));
     }
     #[inline]
     fn i64(&mut self, value: i64) {
-        self.field("i64", &value);
+        self.entry(&format_args!("i64: {}", value));
     }
     #[inline]
     fn u128(&mut self, value: u128) {
-        self.field("u128", &value);
+        self.entry(&format_args!("u128: {}", value));
     }
     #[inline]
     fn i128(&mut self, value: i128) {
-        self.field("i128", &value);
+        self.entry(&format_args!("i128: {}", value));
     }
     #[inline]
     fn f32(&mut self, value: f32) {
-        self.field("f32", &value);
+        self.entry(&format_args!("f32: {}", value));
     }
     #[inline]
     fn f64(&mut self, value: f64) {
-        self.field("f64", &value);
+        self.entry(&format_args!("f64: {}", value));
     }
     #[inline]
     fn str(&mut self, value: Cow<'_, str>) {
         let value: &str = &value;
-        self.field("str", &value);
+        self.entry(&format_args!("str: {:?}", value));
     }
     #[inline]
     fn bytes(&mut self, value: Cow<'_, [u8]>) {
         match String::from_utf8(value.to_vec()) {
-            Ok(s) => self.field("bytes", &format_args!("b{s:?}")),
-            Err(_) => self.field("bytes", &value.as_ref()),
+            Ok(s) => self.entry(&format_args!("bytes: b{:?}", s)),
+            Err(_) => self.entry(&format_args!("bytes: {:?}", value)),
         };
     }
 }


### PR DESCRIPTION
Use debug set instead of nested debug struct for links. Rename DataFormatter to Format.
And trait Method to get verbosity.
Split more trait methods.
Simplify streaming and serial formatting.