### PR TITLE
refactor(rr/Query): keep accepted types in default request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datalink"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 
 [features]
@@ -18,5 +18,5 @@ rand = { version = "0.8", optional = true }
 serde_json = { version = "1.0", optional = true }
 thiserror = "1.0"
 toml = { version = "0.8", optional = true }
-datalink_derive = { git = "https://github.com/SebastianSpeitel/datalink_derive", version = "0.3.0", rev = "0821903", optional = true }
+datalink_derive = { git = "https://github.com/SebastianSpeitel/datalink_derive", version = "0.4.0", rev = "348eda8", optional = true }
 filters = { git = "https://github.com/SebastianSpeitel/filters" }

--- a/src/data.rs
+++ b/src/data.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use crate::{
     links::{LinkError, Links, LinksExt},
-    value::{Provided, Req, ValueRequest},
+    value::{Provided, ValueQuery, ValueRequest},
 };
 
 #[cfg(feature = "unique")]
@@ -31,7 +31,7 @@ pub type BoxedData = Box<dyn Data>;
 pub trait Data {
     #[allow(unused_variables)]
     #[inline]
-    fn provide_value(&self, request: ValueRequest) {}
+    fn provide_value(&self, request: &mut ValueRequest) {}
 
     #[allow(unused_variables)]
     #[inline]
@@ -63,7 +63,7 @@ pub trait Data {
     #[inline]
     #[must_use]
     #[allow(unused_variables)]
-    fn provide_requested<R: Req>(&self, request: &mut ValueRequest<R>) -> impl Provided
+    fn provide_requested<Q: ValueQuery>(&self, request: &mut ValueRequest<Q>) -> impl Provided
     where
         Self: Sized,
     {

--- a/src/data/constant.rs
+++ b/src/data/constant.rs
@@ -87,12 +87,12 @@ where
     for<'d> &'d D: Data,
 {
     #[inline]
-    fn provide_value(&self, request: Request) {
+    fn provide_value(&self, request: &mut Request) {
         (&self.0).provide_value(request);
     }
 
     #[inline]
-    fn provide_requested<R: crate::rr::Req>(&self, request: &mut Request<R>) -> impl Provided
+    fn provide_requested<Q: crate::rr::Query>(&self, request: &mut Request<Q>) -> impl Provided
     where
         Self: Sized,
     {

--- a/src/data/format.rs
+++ b/src/data/format.rs
@@ -268,7 +268,7 @@ impl<const SERIAL: bool, const MAX_DEPTH: u16, const VERBOSITY: i8> Format
                         return false;
                     }
 
-                    if meta::MetaTypes::default().contains_type_of(val) {
+                    if meta::META_TYPES.contains_type_of(val) {
                         return !Self::HIDE_META;
                     }
 
@@ -537,7 +537,7 @@ impl<F: Format + ?Sized> Receiver for DebugReceiver<'_, '_, '_, F> {
             return;
         }
 
-        if !F::HIDE_META && meta::MetaTypes::default().contains_type_of(value) {
+        if !F::HIDE_META && meta::META_TYPES.contains_type_of(value) {
             let info = meta::MetaInfo::about_val(value);
             self.set.entry(&format_args!("{info}"));
             return;

--- a/src/data/format.rs
+++ b/src/data/format.rs
@@ -5,9 +5,8 @@ use std::{
 
 use crate::{
     data::{BoxedData, Data},
-    links::Link,
-    links::{Links, MaybeKeyed, Result, CONTINUE},
-    rr::{meta, Receiver, Request},
+    links::{Link, Links, MaybeKeyed, Result, CONTINUE},
+    rr::{meta, Receiver, Request, TypeSet},
 };
 
 use super::DataExt;
@@ -269,7 +268,7 @@ impl<const SERIAL: bool, const MAX_DEPTH: u16, const VERBOSITY: i8> Format
                         return false;
                     }
 
-                    if meta::MetaInfo::about_val(val).name().is_some() {
+                    if meta::MetaTypes::default().contains_type_of(val) {
                         return !Self::HIDE_META;
                     }
 
@@ -538,8 +537,8 @@ impl<F: Format + ?Sized> Receiver for DebugReceiver<'_, '_, '_, F> {
             return;
         }
 
-        let info = meta::MetaInfo::about_val(value);
-        if !F::HIDE_META && info.name().is_some() {
+        if !F::HIDE_META && meta::MetaTypes::default().contains_type_of(value) {
+            let info = meta::MetaInfo::about_val(value);
             self.set.entry(&format_args!("{info}"));
             return;
         }

--- a/src/data/impls.rs
+++ b/src/data/impls.rs
@@ -13,13 +13,13 @@ macro_rules! impl_deref {
     ($ty:ty) => {
         impl<D: $crate::data::Data> $crate::data::Data for $ty {
             #[inline]
-            fn provide_value(&self, request: $crate::rr::Request) {
+            fn provide_value(&self, request: &mut $crate::rr::Request) {
                 (**self).provide_value(request)
             }
             #[inline]
-            fn provide_requested<R: $crate::rr::Req>(
+            fn provide_requested<Q: $crate::rr::Query>(
                 &self,
-                request: &mut $crate::rr::Request<R>,
+                request: &mut $crate::rr::Request<Q>,
             ) -> impl $crate::data::Provided {
                 (**self).provide_requested(request)
             }
@@ -69,7 +69,7 @@ macro_rules! impl_dyn {
     ($ty:ty) => {
         impl Data for $ty {
             #[inline]
-            fn provide_value(&self, request: crate::rr::Request) {
+            fn provide_value(&self, request: &mut crate::rr::Request) {
                 (**self).provide_value(request);
             }
             #[inline]

--- a/src/data/impls/std.rs
+++ b/src/data/impls/std.rs
@@ -2,16 +2,16 @@ use ::std::collections::HashMap;
 
 use crate::data::{Data, Provided};
 use crate::links::{LinkError, Links, LinksExt};
-use crate::rr::{Req, Request};
+use crate::rr::{Query, Request};
 
 impl Data for String {
     #[inline]
-    fn provide_value(&self, mut request: Request) {
-        self.provide_requested(&mut request).debug_assert_provided();
+    fn provide_value(&self, request: &mut Request) {
+        self.provide_requested(request).debug_assert_provided();
     }
 
     #[inline]
-    fn provide_requested<R: Req>(&self, request: &mut Request<R>) -> impl Provided {
+    fn provide_requested<Q: Query>(&self, request: &mut Request<Q>) -> impl Provided {
         request.provide_str(self);
     }
 }
@@ -23,15 +23,15 @@ mod path {
 
     impl Data for PathBuf {
         #[inline]
-        fn provide_value(&self, mut request: Request) {
-            self.provide_requested(&mut request).debug_assert_provided();
+        fn provide_value(&self, request: &mut Request) {
+            self.provide_requested(request).debug_assert_provided();
         }
 
         #[inline]
-        fn provide_requested<R: Req>(&self, request: &mut Request<R>) -> impl Provided {
+        fn provide_requested<Q: Query>(&self, request: &mut Request<Q>) -> impl Provided {
             request.provide_ref(self);
 
-            if R::requests::<str>() {
+            if request.requests::<&str>() {
                 request.provide_str(self.to_string_lossy().as_ref());
             }
 
@@ -42,15 +42,15 @@ mod path {
 
     impl Data for Path {
         #[inline]
-        fn provide_value(&self, mut request: Request) {
+        fn provide_value(&self, request: &mut Request) {
             request.provide_str(self.to_string_lossy().as_ref());
             #[cfg(target_os = "linux")]
             request.provide_bytes(OsStrExt::as_bytes(self.as_os_str()));
         }
 
         #[inline]
-        fn provide_requested<R: Req>(&self, request: &mut Request<R>) -> impl Provided {
-            if R::requests::<str>() {
+        fn provide_requested<Q: Query>(&self, request: &mut Request<Q>) -> impl Provided {
+            if request.requests::<&str>() {
                 request.provide_str(self.to_string_lossy().as_ref());
             }
 
@@ -68,15 +68,15 @@ mod ffi {
 
     impl Data for OsString {
         #[inline]
-        fn provide_value(&self, mut request: Request) {
-            self.provide_requested(&mut request).debug_assert_provided();
+        fn provide_value(&self, request: &mut Request) {
+            self.provide_requested(request).debug_assert_provided();
         }
 
         #[inline]
-        fn provide_requested<R: Req>(&self, request: &mut Request<R>) -> impl Provided {
+        fn provide_requested<Q: Query>(&self, request: &mut Request<Q>) -> impl Provided {
             request.provide_ref(self);
 
-            if R::requests::<str>() {
+            if request.requests::<&str>() {
                 request.provide_str(self.to_string_lossy().as_ref());
             }
 
@@ -87,15 +87,15 @@ mod ffi {
 
     impl Data for OsStr {
         #[inline]
-        fn provide_value(&self, mut request: Request) {
+        fn provide_value(&self, request: &mut Request) {
             request.provide_str(self.to_string_lossy().as_ref());
             #[cfg(target_os = "linux")]
             request.provide_bytes(OsStrExt::as_bytes(self));
         }
 
         #[inline]
-        fn provide_requested<R: Req>(&self, request: &mut Request<R>) -> impl Provided {
-            if R::requests::<str>() {
+        fn provide_requested<Q: Query>(&self, request: &mut Request<Q>) -> impl Provided {
+            if request.requests::<&str>() {
                 request.provide_str(self.to_string_lossy().as_ref());
             }
 
@@ -119,14 +119,14 @@ mod net {
 
     impl Data for net::Ipv4Addr {
         #[inline]
-        fn provide_value(&self, mut request: Request) {
-            self.provide_requested(&mut request).debug_assert_provided();
+        fn provide_value(&self, request: &mut Request) {
+            self.provide_requested(request).debug_assert_provided();
         }
 
         #[inline]
-        fn provide_requested<R: Req>(&self, request: &mut Request<R>) -> impl Provided {
+        fn provide_requested<Q: Query>(&self, request: &mut Request<Q>) -> impl Provided {
             request.provide_ref(self);
-            if R::requests::<String>() {
+            if request.requests::<String>() {
                 request.provide_str_owned(self.to_string());
             }
         }
@@ -134,14 +134,14 @@ mod net {
 
     impl Data for net::Ipv6Addr {
         #[inline]
-        fn provide_value(&self, mut request: Request) {
-            self.provide_requested(&mut request).debug_assert_provided();
+        fn provide_value(&self, request: &mut Request) {
+            self.provide_requested(request).debug_assert_provided();
         }
 
         #[inline]
-        fn provide_requested<R: Req>(&self, request: &mut Request<R>) -> impl Provided {
+        fn provide_requested<Q: Query>(&self, request: &mut Request<Q>) -> impl Provided {
             request.provide_ref(self);
-            if R::requests::<String>() {
+            if request.requests::<String>() {
                 request.provide_str_owned(self.to_string());
             }
         }
@@ -149,12 +149,12 @@ mod net {
 
     impl Data for net::IpAddr {
         #[inline]
-        fn provide_value(&self, mut request: Request) {
-            self.provide_requested(&mut request).debug_assert_provided();
+        fn provide_value(&self, request: &mut Request) {
+            self.provide_requested(request).debug_assert_provided();
         }
 
         #[inline]
-        fn provide_requested<R: Req>(&self, request: &mut Request<R>) -> impl Provided {
+        fn provide_requested<Q: Query>(&self, request: &mut Request<Q>) -> impl Provided {
             match self {
                 net::IpAddr::V4(ip) => ip.provide_requested(request).was_provided(),
                 net::IpAddr::V6(ip) => ip.provide_requested(request).was_provided(),
@@ -172,15 +172,15 @@ mod net {
 
     impl Data for net::SocketAddrV4 {
         #[inline]
-        fn provide_value(&self, mut request: Request) {
-            self.provide_requested(&mut request).debug_assert_provided();
+        fn provide_value(&self, request: &mut Request) {
+            self.provide_requested(request).debug_assert_provided();
         }
 
         #[inline]
-        fn provide_requested<R: Req>(&self, request: &mut Request<R>) -> impl Provided {
+        fn provide_requested<Q: Query>(&self, request: &mut Request<Q>) -> impl Provided {
             request.provide_ref(self);
 
-            if R::requests::<String>() {
+            if request.requests::<String>() {
                 request.provide_str_owned(self.to_string());
             }
         }
@@ -196,15 +196,15 @@ mod net {
 
     impl Data for net::SocketAddrV6 {
         #[inline]
-        fn provide_value(&self, mut request: Request) {
-            self.provide_requested(&mut request).debug_assert_provided();
+        fn provide_value(&self, request: &mut Request) {
+            self.provide_requested(request).debug_assert_provided();
         }
 
         #[inline]
-        fn provide_requested<R: Req>(&self, request: &mut Request<R>) -> impl Provided {
+        fn provide_requested<Q: Query>(&self, request: &mut Request<Q>) -> impl Provided {
             request.provide_ref(self);
 
-            if R::requests::<String>() {
+            if request.requests::<String>() {
                 request.provide_str_owned(self.to_string());
             }
         }
@@ -220,12 +220,12 @@ mod net {
 
     impl Data for net::SocketAddr {
         #[inline]
-        fn provide_value(&self, mut request: Request) {
-            self.provide_requested(&mut request).debug_assert_provided();
+        fn provide_value(&self, request: &mut Request) {
+            self.provide_requested(request).debug_assert_provided();
         }
 
         #[inline]
-        fn provide_requested<R: Req>(&self, request: &mut Request<R>) -> impl Provided {
+        fn provide_requested<Q: Query>(&self, request: &mut Request<Q>) -> impl Provided {
             match self {
                 net::SocketAddr::V4(addr) => addr.provide_requested(request).was_provided(),
                 net::SocketAddr::V6(addr) => addr.provide_requested(request).was_provided(),

--- a/src/data/impls/toml.rs
+++ b/src/data/impls/toml.rs
@@ -2,15 +2,15 @@ use ::toml::{Table, Value as Val};
 
 use crate::data::Data;
 use crate::links::{LinkError, Links, LinksExt};
-use crate::rr::prelude::{Provided, Req, Request};
+use crate::rr::prelude::{Provided, Query, Request};
 
 impl Data for Val {
     #[inline]
-    fn provide_value(&self, mut request: Request) {
-        self.provide_requested(&mut request).debug_assert_provided();
+    fn provide_value(&self, request: &mut Request) {
+        self.provide_requested(request).debug_assert_provided();
     }
     #[inline]
-    fn provide_requested<R: Req>(&self, request: &mut Request<R>) -> impl Provided {
+    fn provide_requested<Q: Query>(&self, request: &mut Request<Q>) -> impl Provided {
         match self {
             Val::String(s) => request.provide_str(s),
             Val::Integer(i) => request.provide_ref(i),
@@ -18,7 +18,7 @@ impl Data for Val {
             Val::Boolean(b) => request.provide_ref(b),
             Val::Datetime(dt) => {
                 request.provide_ref(dt);
-                if R::requests::<String>() {
+                if request.requests::<String>() {
                     request.provide_str_owned(dt.to_string());
                 }
             }

--- a/src/data/unique.rs
+++ b/src/data/unique.rs
@@ -85,13 +85,13 @@ impl<D: Data + ?Sized, T: Borrow<D>> AsRef<D> for Fixed<D, T> {
 #[warn(clippy::missing_trait_methods)]
 impl<D: Data + ?Sized, T: Borrow<D>> Data for Fixed<D, T> {
     #[inline]
-    fn provide_value(&self, request: Request) {
+    fn provide_value(&self, request: &mut Request) {
         self.as_ref().provide_value(request);
     }
     #[inline]
-    fn provide_requested<R: crate::rr::Req>(
+    fn provide_requested<Q: crate::rr::Query>(
         &self,
-        _request: &mut Request<R>,
+        _request: &mut Request<Q>,
     ) -> impl super::Provided
     where
         Self: Sized,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -52,16 +52,16 @@ macro_rules! impl_data {
         impl $crate::data::Data for $name {
             $(
                 #[inline]
-                fn provide_value(&self, mut request: $crate::value::ValueRequest) {
+                fn provide_value(&self, request: &mut $crate::value::ValueRequest) {
                     $(
                         request.provide_owned($val);
                     )+
                 }
 
                 #[inline]
-                fn provide_requested<R: $crate::value::Req>(
+                fn provide_requested<Q: $crate::rr::Query>(
                     &self,
-                    request: &mut $crate::value::ValueRequest<R>,
+                    request: &mut $crate::value::ValueRequest<Q>,
                 ) -> impl $crate::value::Provided {
                     $(
                         request.provide_owned($val);

--- a/src/query/datafilter.rs
+++ b/src/query/datafilter.rs
@@ -167,7 +167,7 @@ impl<D: Data + ?Sized> Filter<D> for DataFilter {
                     }
                     #[inline]
                     fn accepting() -> impl crate::rr::typeset::TypeSet + 'static {
-                        crate::rr::typeset::StringLike::default()
+                        crate::rr::typeset::STRING_LIKE
                     }
                 }
 

--- a/src/query/datafilter.rs
+++ b/src/query/datafilter.rs
@@ -166,10 +166,7 @@ impl<D: Data + ?Sized> Filter<D> for DataFilter {
                         }
                     }
                     #[inline]
-                    fn accepting() -> impl crate::rr::typeset::TypeSet + 'static
-                    where
-                        Self: Sized,
-                    {
+                    fn accepting() -> impl crate::rr::typeset::TypeSet + 'static {
                         crate::rr::typeset::StringLike::default()
                     }
                 }

--- a/src/rr/erased.rs
+++ b/src/rr/erased.rs
@@ -125,12 +125,12 @@ impl<'q> super::query::Query for Erased<'q> {
     type Requesting<'r> = ErasedAccepting<'r>;
 
     #[inline]
-    fn get_receiver<'r>(request: &'r mut Self::Request) -> Self::Receiver<'r> {
+    fn get_receiver(request: &mut Self::Request) -> Self::Receiver<'_> {
         ErasedReceiver(*request)
     }
 
     #[inline]
-    fn get_requesting<'r>(request: &'r Self::Request) -> Self::Requesting<'r> {
+    fn get_requesting(request: &Self::Request) -> Self::Requesting<'_> {
         ErasedAccepting(*request)
     }
 }

--- a/src/rr/erased.rs
+++ b/src/rr/erased.rs
@@ -1,0 +1,138 @@
+use core::{any::Any, marker::PhantomData};
+
+use super::receiver::{Receiver, ReceiverExt};
+
+pub struct ErasedReceiver<'r>(&'r mut dyn ReceiverExt);
+
+impl core::fmt::Debug for ErasedReceiver<'_> {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ErasedReceiver").finish()
+    }
+}
+
+#[warn(clippy::missing_trait_methods)]
+impl Receiver for ErasedReceiver<'_> {
+    #[inline]
+    fn bool(&mut self, value: bool) {
+        self.0.bool(value);
+    }
+    #[inline]
+    fn i8(&mut self, value: i8) {
+        self.0.i8(value);
+    }
+    #[inline]
+    fn u8(&mut self, value: u8) {
+        self.0.u8(value);
+    }
+    #[inline]
+    fn i16(&mut self, value: i16) {
+        self.0.i16(value);
+    }
+    #[inline]
+    fn u16(&mut self, value: u16) {
+        self.0.u16(value);
+    }
+    #[inline]
+    fn i32(&mut self, value: i32) {
+        self.0.i32(value);
+    }
+    #[inline]
+    fn u32(&mut self, value: u32) {
+        self.0.u32(value);
+    }
+    #[inline]
+    fn i64(&mut self, value: i64) {
+        self.0.i64(value);
+    }
+    #[inline]
+    fn u64(&mut self, value: u64) {
+        self.0.u64(value);
+    }
+    #[inline]
+    fn i128(&mut self, value: i128) {
+        self.0.i128(value);
+    }
+    #[inline]
+    fn u128(&mut self, value: u128) {
+        self.0.u128(value);
+    }
+    #[inline]
+    fn f32(&mut self, value: f32) {
+        self.0.f32(value);
+    }
+    #[inline]
+    fn f64(&mut self, value: f64) {
+        self.0.f64(value);
+    }
+    #[inline]
+    fn char(&mut self, value: char) {
+        self.0.char(value);
+    }
+    #[inline]
+    fn str(&mut self, value: &str) {
+        self.0.str(value);
+    }
+    #[inline]
+    fn str_owned(&mut self, value: String) {
+        self.0.str_owned(value);
+    }
+    #[inline]
+    fn bytes(&mut self, value: &[u8]) {
+        self.0.bytes(value);
+    }
+    #[inline]
+    fn bytes_owned(&mut self, value: Vec<u8>) {
+        self.0.bytes_owned(value);
+    }
+    #[inline]
+    fn other_ref(&mut self, value: &dyn Any) {
+        self.0.other_ref(value);
+    }
+    #[inline]
+    fn other_boxed(&mut self, value: Box<dyn Any>) {
+        self.0.other_boxed(value);
+    }
+    #[inline]
+    fn accepting() -> impl super::TypeSet + 'static {
+        #[derive(Debug, Default, Clone, Copy)]
+        struct ErasedReceiverError;
+        super::typeset::Invalid::<ErasedReceiverError>::default()
+    }
+}
+
+pub struct ErasedAccepting<'r>(&'r dyn super::receiver::ReceiverExt);
+
+impl core::fmt::Debug for ErasedAccepting<'_> {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ErasedAccepting").finish()
+    }
+}
+
+impl super::TypeSet for ErasedAccepting<'_> {
+    type Error = core::convert::Infallible;
+    #[inline]
+    fn contains_id_checked(&self, type_id: core::any::TypeId) -> Result<bool, Self::Error> {
+        Ok(self.0.accepts_id(type_id))
+    }
+}
+
+#[derive(Debug)]
+pub struct Erased<'q>(PhantomData<&'q ()>);
+
+impl<'q> super::query::Query for Erased<'q> {
+    type Request = &'q mut dyn ReceiverExt;
+    type Receiver<'r> = ErasedReceiver<'r>;
+    type Requesting<'r> = ErasedAccepting<'r>;
+
+    #[inline]
+    fn get_receiver<'r>(request: &'r mut Self::Request) -> Self::Receiver<'r> {
+        ErasedReceiver(*request)
+    }
+
+    #[inline]
+    fn get_requesting<'r>(request: &'r Self::Request) -> Self::Requesting<'r> {
+        ErasedAccepting(*request)
+    }
+}

--- a/src/rr/erased.rs
+++ b/src/rr/erased.rs
@@ -95,9 +95,8 @@ impl Receiver for ErasedReceiver<'_> {
     }
     #[inline]
     fn accepting() -> impl super::TypeSet + 'static {
-        #[derive(Debug, Default, Clone, Copy)]
-        struct ErasedReceiverError;
-        super::typeset::Invalid::<ErasedReceiverError>::default()
+        debug_assert!(false, "ErasedReceiver::accepting() should not be called");
+        super::typeset::All
     }
 }
 
@@ -111,10 +110,9 @@ impl core::fmt::Debug for ErasedAccepting<'_> {
 }
 
 impl super::TypeSet for ErasedAccepting<'_> {
-    type Error = core::convert::Infallible;
     #[inline]
-    fn contains_id_checked(&self, type_id: core::any::TypeId) -> Result<bool, Self::Error> {
-        Ok(self.0.accepts_id(type_id))
+    fn contains_id(&self, type_id: core::any::TypeId) -> bool {
+        self.0.accepts_id(type_id)
     }
 }
 

--- a/src/rr/meta.rs
+++ b/src/rr/meta.rs
@@ -73,3 +73,5 @@ impl From<TypeId> for MetaInfo {
 }
 
 pub type MetaTypes = super::typeset::AnyOf<(IsNone, IsSome, IsBorrowed, IsNull, IsOwned, IsUnit)>;
+
+pub const META_TYPES: MetaTypes = super::typeset::AnyOf::new();

--- a/src/rr/meta.rs
+++ b/src/rr/meta.rs
@@ -71,3 +71,5 @@ impl From<TypeId> for MetaInfo {
         Self::new(type_id)
     }
 }
+
+pub type MetaTypes = super::typeset::AnyOf<(IsNone, IsSome, IsBorrowed, IsNull, IsOwned, IsUnit)>;

--- a/src/rr/mod.rs
+++ b/src/rr/mod.rs
@@ -1,56 +1,21 @@
+pub mod erased;
 pub mod meta;
 pub mod provided;
+pub mod query;
 pub mod receiver;
 pub mod request;
+pub mod typeset;
 
+pub use query::Query;
 pub use receiver::Receiver;
 pub use request::Request;
+pub use typeset::TypeSet;
 
 pub mod prelude {
     pub use super::provided::Provided;
+    pub use super::query::Query;
     pub use super::receiver::Receiver;
     pub use super::request::Request;
-    pub use super::Req;
-}
-
-pub trait Req: 'static {
-    type Receiver<'d>: Receiver;
-
-    #[inline]
-    #[must_use]
-    fn requests<T: 'static + ?Sized>() -> bool {
-        Self::Receiver::accepts::<T>()
-    }
-}
-
-#[derive(Debug)]
-pub struct Unknown;
-impl Req for Unknown {
-    type Receiver<'d> = &'d mut dyn Receiver;
-}
-
-#[derive(Debug)]
-pub struct RefOption<T>(core::marker::PhantomData<T>);
-impl<T> Req for RefOption<T>
-where
-    T: 'static,
-    for<'a> &'a mut Option<T>: Receiver,
-{
-    type Receiver<'d> = &'d mut Option<T>;
-}
-
-#[derive(Debug)]
-pub struct IgnoreMeta<R: Req>(core::marker::PhantomData<R>);
-impl<R: Req> Req for IgnoreMeta<R> {
-    type Receiver<'d> = R::Receiver<'d>;
-
-    #[inline]
-    fn requests<T: 'static + ?Sized>() -> bool {
-        if meta::MetaInfo::about::<T>().name().is_some() {
-            return false;
-        }
-        R::requests::<T>()
-    }
 }
 
 #[macro_export]

--- a/src/rr/query.rs
+++ b/src/rr/query.rs
@@ -6,7 +6,7 @@ use super::{
 pub trait Query {
     type Request;
     type Receiver<'r>: Receiver;
-    type Requesting<'r>: TypeSet<Error = core::convert::Infallible>;
+    type Requesting<'r>: TypeSet;
 
     fn get_receiver<'r>(request: &'r mut Self::Request) -> Self::Receiver<'r>;
 

--- a/src/rr/query.rs
+++ b/src/rr/query.rs
@@ -8,9 +8,9 @@ pub trait Query {
     type Receiver<'r>: Receiver;
     type Requesting<'r>: TypeSet;
 
-    fn get_receiver<'r>(request: &'r mut Self::Request) -> Self::Receiver<'r>;
+    fn get_receiver(request: &mut Self::Request) -> Self::Receiver<'_>;
 
-    fn get_requesting<'r>(request: &'r Self::Request) -> Self::Requesting<'r>;
+    fn get_requesting(request: &Self::Request) -> Self::Requesting<'_>;
 }
 
 #[derive(Debug)]
@@ -27,7 +27,7 @@ impl<Q: Query> Query for IgnoreMeta<Q> {
     }
 
     #[inline]
-    fn get_requesting<'r>(request: &'r Self::Request) -> Self::Requesting<'r> {
+    fn get_requesting(request: &Self::Request) -> Self::Requesting<'_> {
         typeset::And(
             Q::get_requesting(request),
             typeset::Not(super::meta::MetaTypes::default()),
@@ -46,7 +46,7 @@ impl<R: Receiver + 'static> Query for R {
     }
 
     #[inline]
-    fn get_requesting<'r>(_request: &'r Self::Request) -> Self::Requesting<'r> {
+    fn get_requesting(_request: &Self::Request) -> Self::Requesting<'_> {
         typeset::AcceptedBy::new()
     }
 }

--- a/src/rr/query.rs
+++ b/src/rr/query.rs
@@ -1,0 +1,52 @@
+use super::{
+    typeset::{self, TypeSet},
+    Receiver,
+};
+
+pub trait Query {
+    type Request;
+    type Receiver<'r>: Receiver;
+    type Requesting<'r>: TypeSet<Error = core::convert::Infallible>;
+
+    fn get_receiver<'r>(request: &'r mut Self::Request) -> Self::Receiver<'r>;
+
+    fn get_requesting<'r>(request: &'r Self::Request) -> Self::Requesting<'r>;
+}
+
+#[derive(Debug)]
+pub struct IgnoreMeta<Q: Query>(core::marker::PhantomData<Q>);
+
+impl<Q: Query> Query for IgnoreMeta<Q> {
+    type Request = Q::Request;
+    type Receiver<'r> = Q::Receiver<'r>;
+    type Requesting<'r> = typeset::And<Q::Requesting<'r>, typeset::Not<super::meta::MetaTypes>>;
+
+    #[inline]
+    fn get_receiver(request: &mut Self::Request) -> Self::Receiver<'_> {
+        Q::get_receiver(request)
+    }
+
+    #[inline]
+    fn get_requesting<'r>(request: &'r Self::Request) -> Self::Requesting<'r> {
+        typeset::And(
+            Q::get_requesting(request),
+            typeset::Not(super::meta::MetaTypes::default()),
+        )
+    }
+}
+
+impl<R: Receiver + 'static> Query for R {
+    type Request = R;
+    type Receiver<'r> = &'r mut R;
+    type Requesting<'r> = typeset::AcceptedBy<R>;
+
+    #[inline]
+    fn get_receiver(request: &mut Self::Request) -> Self::Receiver<'_> {
+        request
+    }
+
+    #[inline]
+    fn get_requesting<'r>(_request: &'r Self::Request) -> Self::Requesting<'r> {
+        typeset::AcceptedBy::new()
+    }
+}

--- a/src/rr/query.rs
+++ b/src/rr/query.rs
@@ -30,7 +30,7 @@ impl<Q: Query> Query for IgnoreMeta<Q> {
     fn get_requesting(request: &Self::Request) -> Self::Requesting<'_> {
         typeset::And(
             Q::get_requesting(request),
-            typeset::Not(super::meta::MetaTypes::default()),
+            typeset::Not(super::meta::META_TYPES),
         )
     }
 }

--- a/src/rr/receiver.rs
+++ b/src/rr/receiver.rs
@@ -294,7 +294,7 @@ impl Receiver for Option<String> {
 
     #[inline]
     fn accepting() -> impl super::TypeSet + 'static {
-        super::typeset::StringLike::default()
+        super::typeset::STRING_LIKE
     }
 }
 
@@ -311,7 +311,7 @@ impl Receiver for Option<Vec<u8>> {
 
     #[inline]
     fn accepting() -> impl super::TypeSet + 'static {
-        super::typeset::BytesLike::default()
+        super::typeset::BYTES_LIKE
     }
 }
 

--- a/src/rr/receiver.rs
+++ b/src/rr/receiver.rs
@@ -155,116 +155,99 @@ pub trait Receiver {
 
     #[inline]
     #[must_use]
-    fn accepts<T: 'static + ?Sized>() -> bool
+    fn accepting() -> impl super::TypeSet + 'static
     where
         Self: Sized,
     {
-        true
-    }
-}
-
-macro_rules! receiver_deref_fns {
-    () => {
-        #[inline]
-        fn bool(&mut self, value: bool) {
-            (**self).bool(value);
-        }
-        #[inline]
-        fn i8(&mut self, value: i8) {
-            (**self).i8(value);
-        }
-        #[inline]
-        fn u8(&mut self, value: u8) {
-            (**self).u8(value);
-        }
-        #[inline]
-        fn i16(&mut self, value: i16) {
-            (**self).i16(value);
-        }
-        #[inline]
-        fn u16(&mut self, value: u16) {
-            (**self).u16(value);
-        }
-        #[inline]
-        fn i32(&mut self, value: i32) {
-            (**self).i32(value);
-        }
-        #[inline]
-        fn u32(&mut self, value: u32) {
-            (**self).u32(value);
-        }
-        #[inline]
-        fn i64(&mut self, value: i64) {
-            (**self).i64(value);
-        }
-        #[inline]
-        fn u64(&mut self, value: u64) {
-            (**self).u64(value);
-        }
-        #[inline]
-        fn i128(&mut self, value: i128) {
-            (**self).i128(value);
-        }
-        #[inline]
-        fn u128(&mut self, value: u128) {
-            (**self).u128(value);
-        }
-        #[inline]
-        fn f32(&mut self, value: f32) {
-            (**self).f32(value);
-        }
-        #[inline]
-        fn f64(&mut self, value: f64) {
-            (**self).f64(value);
-        }
-        #[inline]
-        fn char(&mut self, value: char) {
-            (**self).char(value);
-        }
-        #[inline]
-        fn str(&mut self, value: &str) {
-            (**self).str(value);
-        }
-        #[inline]
-        fn str_owned(&mut self, value: String) {
-            (**self).str_owned(value);
-        }
-        #[inline]
-        fn bytes(&mut self, value: &[u8]) {
-            (**self).bytes(value);
-        }
-        #[inline]
-        fn bytes_owned(&mut self, value: Vec<u8>) {
-            (**self).bytes_owned(value);
-        }
-        #[inline]
-        fn other_ref(&mut self, value: &dyn Any) {
-            (**self).other_ref(value);
-        }
-        #[inline]
-        fn other_boxed(&mut self, value: Box<dyn Any>) {
-            (**self).other_boxed(value);
-        }
-    };
-}
-
-#[warn(clippy::missing_trait_methods)]
-impl Receiver for &mut dyn Receiver {
-    receiver_deref_fns!();
-
-    #[inline]
-    fn accepts<U: 'static + ?Sized>() -> bool {
-        true
+        super::typeset::All
     }
 }
 
 #[warn(clippy::missing_trait_methods)]
-impl<T: Receiver> Receiver for &mut T {
-    receiver_deref_fns!();
-
+impl<R: Receiver> Receiver for &mut R {
     #[inline]
-    fn accepts<U: Any + ?Sized>() -> bool {
-        T::accepts::<U>()
+    fn bool(&mut self, value: bool) {
+        (**self).bool(value);
+    }
+    #[inline]
+    fn i8(&mut self, value: i8) {
+        (**self).i8(value);
+    }
+    #[inline]
+    fn u8(&mut self, value: u8) {
+        (**self).u8(value);
+    }
+    #[inline]
+    fn i16(&mut self, value: i16) {
+        (**self).i16(value);
+    }
+    #[inline]
+    fn u16(&mut self, value: u16) {
+        (**self).u16(value);
+    }
+    #[inline]
+    fn i32(&mut self, value: i32) {
+        (**self).i32(value);
+    }
+    #[inline]
+    fn u32(&mut self, value: u32) {
+        (**self).u32(value);
+    }
+    #[inline]
+    fn i64(&mut self, value: i64) {
+        (**self).i64(value);
+    }
+    #[inline]
+    fn u64(&mut self, value: u64) {
+        (**self).u64(value);
+    }
+    #[inline]
+    fn i128(&mut self, value: i128) {
+        (**self).i128(value);
+    }
+    #[inline]
+    fn u128(&mut self, value: u128) {
+        (**self).u128(value);
+    }
+    #[inline]
+    fn f32(&mut self, value: f32) {
+        (**self).f32(value);
+    }
+    #[inline]
+    fn f64(&mut self, value: f64) {
+        (**self).f64(value);
+    }
+    #[inline]
+    fn char(&mut self, value: char) {
+        (**self).char(value);
+    }
+    #[inline]
+    fn str(&mut self, value: &str) {
+        (**self).str(value);
+    }
+    #[inline]
+    fn str_owned(&mut self, value: String) {
+        (**self).str_owned(value);
+    }
+    #[inline]
+    fn bytes(&mut self, value: &[u8]) {
+        (**self).bytes(value);
+    }
+    #[inline]
+    fn bytes_owned(&mut self, value: Vec<u8>) {
+        (**self).bytes_owned(value);
+    }
+    #[inline]
+    fn other_ref(&mut self, value: &dyn Any) {
+        (**self).other_ref(value);
+    }
+    #[inline]
+    fn other_boxed(&mut self, value: Box<dyn Any>) {
+        (**self).other_boxed(value);
+    }
+    #[inline]
+    fn accepting() -> impl super::TypeSet + 'static {
+        R::accepting()
     }
 }
 
@@ -276,9 +259,8 @@ macro_rules! impl_option_receiver {
                 self.replace(value);
             }
             #[inline]
-            fn accepts<U: core::any::Any + ?Sized>() -> bool {
-                use core::any::TypeId;
-                TypeId::of::<$ty>() == TypeId::of::<U>()
+            fn accepting() -> impl $crate::rr::typeset::TypeSet + 'static {
+                crate::rr::typeset::Only::<$ty>::default()
             }
         }
     };
@@ -311,13 +293,8 @@ impl Receiver for Option<String> {
     }
 
     #[inline]
-    fn accepts<T: Any + ?Sized>() -> bool
-    where
-        Self: Sized,
-    {
-        use core::any::TypeId;
-        let id = TypeId::of::<T>();
-        id == TypeId::of::<String>() || id == TypeId::of::<&str>()
+    fn accepting() -> impl super::TypeSet + 'static {
+        super::typeset::StringLike::default()
     }
 }
 
@@ -333,12 +310,21 @@ impl Receiver for Option<Vec<u8>> {
     }
 
     #[inline]
-    fn accepts<T: Any + ?Sized>() -> bool
-    where
-        Self: Sized,
-    {
-        use core::any::TypeId;
-        let id = TypeId::of::<T>();
-        id == TypeId::of::<Vec<u8>>() || id == TypeId::of::<&[u8]>()
+    fn accepting() -> impl super::TypeSet + 'static {
+        super::typeset::BytesLike::default()
+    }
+}
+
+pub trait ReceiverExt: Receiver {
+    fn accepts_id(&self, type_id: core::any::TypeId) -> bool;
+}
+
+impl<R: super::Receiver> ReceiverExt for R {
+    #[inline]
+    fn accepts_id(&self, type_id: core::any::TypeId) -> bool {
+        use super::TypeSet;
+        R::accepting()
+            .contains_id_checked(type_id)
+            .unwrap_or_default()
     }
 }

--- a/src/rr/receiver.rs
+++ b/src/rr/receiver.rs
@@ -323,8 +323,6 @@ impl<R: super::Receiver> ReceiverExt for R {
     #[inline]
     fn accepts_id(&self, type_id: core::any::TypeId) -> bool {
         use super::TypeSet;
-        R::accepting()
-            .contains_id_checked(type_id)
-            .unwrap_or_default()
+        R::accepting().contains_id(type_id)
     }
 }

--- a/src/rr/typeset.rs
+++ b/src/rr/typeset.rs
@@ -53,10 +53,18 @@ impl TypeSet for All {
 #[derive(Debug, Clone, Copy)]
 pub struct AnyOf<T: ?Sized>(PhantomData<T>);
 
+impl<T: ?Sized> AnyOf<T> {
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
 impl<T: ?Sized> Default for AnyOf<T> {
     #[inline]
     fn default() -> Self {
-        Self(PhantomData)
+        Self::new()
     }
 }
 

--- a/src/rr/typeset.rs
+++ b/src/rr/typeset.rs
@@ -3,74 +3,23 @@ use core::convert::Infallible;
 use core::marker::PhantomData;
 
 pub trait TypeSet {
-    type Error;
-
-    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error>;
-
-    #[inline]
-    fn contains_type_checked<T: 'static + ?Sized>(&self) -> Result<bool, Self::Error>
-    where
-        Self: Sized,
-    {
-        self.contains_id_checked(TypeId::of::<T>())
-    }
-    #[allow(unused_variables)]
-    #[inline]
-    fn contains_type_of_checked<T: 'static + ?Sized>(&self, value: &T) -> Result<bool, Self::Error>
-    where
-        Self: Sized,
-    {
-        self.contains_type_checked::<T>()
-    }
-
-    #[inline]
-    fn contains_id(&self, type_id: TypeId) -> bool
-    where
-        Self: TypeSet<Error = Infallible> + Sized,
-    {
-        match self.contains_id_checked(type_id) {
-            Ok(result) => result,
-            Err(never) => match never {},
-        }
-    }
+    fn contains_id(&self, type_id: TypeId) -> bool;
     #[inline]
     fn contains_type<T: 'static + ?Sized>(&self) -> bool
     where
-        Self: TypeSet<Error = Infallible> + Sized,
+        Self: Sized,
     {
-        match self.contains_type_checked::<T>() {
-            Ok(result) => result,
-            Err(never) => match never {},
-        }
+        self.contains_id(TypeId::of::<T>())
     }
     #[allow(unused_variables)]
     #[inline]
     fn contains_type_of<T: 'static + ?Sized>(&self, value: &T) -> bool
     where
-        Self: TypeSet<Error = Infallible> + Sized,
+        Self: Sized,
     {
-        match self.contains_type_of_checked::<T>(value) {
-            Ok(result) => result,
-            Err(never) => match never {},
-        }
+        self.contains_type::<T>()
     }
 }
-
-// impl<E> TypeSet for &dyn TypeSet<Error = E> {
-//     type Error = E;
-//     #[inline]
-//     fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
-//         (**self).contains_id_checked(type_id)
-//     }
-// }
-
-// impl<E> TypeSet for Box<dyn TypeSet<Error = E>> {
-//     type Error = E;
-//     #[inline]
-//     fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
-//         (**self).contains_id_checked(type_id)
-//     }
-// }
 
 #[derive(Debug)]
 pub struct Only<T: ?Sized>(PhantomData<T>);
@@ -86,45 +35,19 @@ impl<T> TypeSet for Only<T>
 where
     T: 'static + ?Sized,
 {
-    type Error = Infallible;
     #[inline]
-    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
-        Ok(type_id == TypeId::of::<T>())
+    fn contains_id(&self, type_id: TypeId) -> bool {
+        type_id == TypeId::of::<T>()
     }
 }
-
-// impl<const N: usize> TypeSet for [TypeId; N] {
-//     type Error = Infallible;
-//     #[inline]
-//     fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
-//         Ok(self.contains(&type_id))
-//     }
-// }
-
-// impl TypeSet for Vec<TypeId> {
-//     type Error = Infallible;
-//     #[inline]
-//     fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
-//         Ok(self.contains(&type_id))
-//     }
-// }
-
-// impl TypeSet for [TypeId] {
-//     type Error = Infallible;
-//     #[inline]
-//     fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
-//         Ok(self.contains(&type_id))
-//     }
-// }
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct All;
 
 impl TypeSet for All {
-    type Error = Infallible;
     #[inline]
-    fn contains_id_checked(&self, _type_id: TypeId) -> Result<bool, Self::Error> {
-        Ok(true)
+    fn contains_id(&self, _type_id: TypeId) -> bool {
+        true
     }
 }
 
@@ -142,10 +65,9 @@ impl<T1> TypeSet for AnyOf<(T1,)>
 where
     T1: 'static + ?Sized,
 {
-    type Error = Infallible;
     #[inline]
-    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
-        Ok(type_id == TypeId::of::<T1>())
+    fn contains_id(&self, type_id: TypeId) -> bool {
+        type_id == TypeId::of::<T1>()
     }
 }
 
@@ -154,10 +76,9 @@ where
     T1: 'static,
     T2: 'static,
 {
-    type Error = Infallible;
     #[inline]
-    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
-        Ok(type_id == TypeId::of::<T1>() || type_id == TypeId::of::<T2>())
+    fn contains_id(&self, type_id: TypeId) -> bool {
+        type_id == TypeId::of::<T1>() || type_id == TypeId::of::<T2>()
     }
 }
 
@@ -170,15 +91,14 @@ where
     T5: 'static,
     T6: 'static,
 {
-    type Error = Infallible;
     #[inline]
-    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
-        Ok(type_id == TypeId::of::<T1>()
+    fn contains_id(&self, type_id: TypeId) -> bool {
+        type_id == TypeId::of::<T1>()
             || type_id == TypeId::of::<T2>()
             || type_id == TypeId::of::<T3>()
             || type_id == TypeId::of::<T4>()
             || type_id == TypeId::of::<T5>()
-            || type_id == TypeId::of::<T6>())
+            || type_id == TypeId::of::<T6>()
     }
 }
 
@@ -219,10 +139,9 @@ where
     T15: 'static,
     T16: 'static,
 {
-    type Error = Infallible;
     #[inline]
-    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
-        Ok(type_id == TypeId::of::<T1>()
+    fn contains_id(&self, type_id: TypeId) -> bool {
+        type_id == TypeId::of::<T1>()
             || type_id == TypeId::of::<T2>()
             || type_id == TypeId::of::<T3>()
             || type_id == TypeId::of::<T4>()
@@ -237,7 +156,7 @@ where
             || type_id == TypeId::of::<T13>()
             || type_id == TypeId::of::<T14>()
             || type_id == TypeId::of::<T15>()
-            || type_id == TypeId::of::<T16>())
+            || type_id == TypeId::of::<T16>()
     }
 }
 
@@ -246,24 +165,20 @@ pub struct And<T: TypeSet, U: TypeSet>(pub T, pub U);
 
 impl<T, U> TypeSet for And<T, U>
 where
-    T: TypeSet<Error = Infallible>,
-    U: TypeSet<Error = Infallible>,
+    T: TypeSet,
+    U: TypeSet,
 {
-    type Error = Infallible;
     #[inline]
-    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
-        Ok(self.0.contains_id(type_id) && self.1.contains_id(type_id))
+    fn contains_id(&self, type_id: TypeId) -> bool {
+        self.0.contains_id(type_id) && self.1.contains_id(type_id)
     }
     #[inline]
-    fn contains_type_checked<Typ: 'static + ?Sized>(&self) -> Result<bool, Self::Error> {
-        Ok(self.0.contains_type::<Typ>() && self.1.contains_type::<Typ>())
+    fn contains_type<Typ: 'static + ?Sized>(&self) -> bool {
+        self.0.contains_type::<Typ>() && self.1.contains_type::<Typ>()
     }
     #[inline]
-    fn contains_type_of_checked<Typ: 'static + ?Sized>(
-        &self,
-        val: &Typ,
-    ) -> Result<bool, Self::Error> {
-        Ok(self.0.contains_type_of(val) && self.1.contains_type_of(val))
+    fn contains_type_of<Typ: 'static + ?Sized>(&self, val: &Typ) -> bool {
+        self.0.contains_type_of(val) && self.1.contains_type_of(val)
     }
 }
 
@@ -272,24 +187,20 @@ pub struct Or<T: TypeSet, U: TypeSet>(pub T, pub U);
 
 impl<T, U> TypeSet for Or<T, U>
 where
-    T: TypeSet<Error = Infallible>,
-    U: TypeSet<Error = Infallible>,
+    T: TypeSet,
+    U: TypeSet,
 {
-    type Error = Infallible;
     #[inline]
-    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
-        Ok(self.0.contains_id(type_id) || self.1.contains_id(type_id))
+    fn contains_id(&self, type_id: TypeId) -> bool {
+        self.0.contains_id(type_id) || self.1.contains_id(type_id)
     }
     #[inline]
-    fn contains_type_checked<Typ: 'static + ?Sized>(&self) -> Result<bool, Self::Error> {
-        Ok(self.0.contains_type::<Typ>() || self.1.contains_type::<Typ>())
+    fn contains_type<Typ: 'static + ?Sized>(&self) -> bool {
+        self.0.contains_type::<Typ>() || self.1.contains_type::<Typ>()
     }
     #[inline]
-    fn contains_type_of_checked<Typ: 'static + ?Sized>(
-        &self,
-        val: &Typ,
-    ) -> Result<bool, Self::Error> {
-        Ok(self.0.contains_type_of(val) || self.1.contains_type_of(val))
+    fn contains_type_of<Typ: 'static + ?Sized>(&self, val: &Typ) -> bool {
+        self.0.contains_type_of(val) || self.1.contains_type_of(val)
     }
 }
 
@@ -297,21 +208,17 @@ where
 pub struct Not<T: TypeSet>(pub T);
 
 impl<T: TypeSet> TypeSet for Not<T> {
-    type Error = T::Error;
     #[inline]
-    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
-        self.0.contains_id_checked(type_id).map(|result| !result)
+    fn contains_id(&self, type_id: TypeId) -> bool {
+        !self.0.contains_id(type_id)
     }
     #[inline]
-    fn contains_type_checked<Typ: 'static + ?Sized>(&self) -> Result<bool, Self::Error> {
-        self.0.contains_type_checked::<Typ>().map(|result| !result)
+    fn contains_type<Typ: 'static + ?Sized>(&self) -> bool {
+        !self.0.contains_type::<Typ>()
     }
     #[inline]
-    fn contains_type_of_checked<Typ: 'static + ?Sized>(
-        &self,
-        val: &Typ,
-    ) -> Result<bool, Self::Error> {
-        self.0.contains_type_of_checked(val).map(|result| !result)
+    fn contains_type_of<Typ: 'static + ?Sized>(&self, val: &Typ) -> bool {
+        !self.0.contains_type_of(val)
     }
 }
 
@@ -338,38 +245,17 @@ impl<R> Default for AcceptedBy<R> {
 }
 
 impl<R: super::Receiver> TypeSet for AcceptedBy<R> {
-    type Error = Infallible;
     #[inline]
-    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
-        Ok(R::accepting()
-            .contains_id_checked(type_id)
-            .unwrap_or_default())
+    fn contains_id(&self, type_id: TypeId) -> bool {
+        R::accepting().contains_id(type_id)
     }
     #[inline]
-    fn contains_type_checked<T: 'static + ?Sized>(&self) -> Result<bool, Self::Error> {
-        Ok(R::accepting()
-            .contains_type_checked::<T>()
-            .unwrap_or_default())
+    fn contains_type<T: 'static + ?Sized>(&self) -> bool {
+        R::accepting().contains_type::<T>()
     }
     #[inline]
-    fn contains_type_of_checked<T: 'static + ?Sized>(
-        &self,
-        value: &T,
-    ) -> Result<bool, Self::Error> {
-        Ok(R::accepting()
-            .contains_type_of_checked(value)
-            .unwrap_or_default())
-    }
-}
-
-#[derive(Debug, Default, Clone, Copy)]
-pub struct Invalid<E>(E);
-
-impl<E: Clone> TypeSet for Invalid<E> {
-    type Error = E;
-    #[inline]
-    fn contains_id_checked(&self, _type_id: TypeId) -> Result<bool, Self::Error> {
-        Err(self.0.clone())
+    fn contains_type_of<T: 'static + ?Sized>(&self, value: &T) -> bool {
+        R::accepting().contains_type_of(value)
     }
 }
 
@@ -382,14 +268,6 @@ mod tests {
         let set = Only::<u8>::default();
         assert!(set.contains_type::<u8>());
         assert!(!set.contains_type::<u16>());
-    }
-
-    #[test]
-    fn infallible_result_size() {
-        assert_eq!(
-            core::mem::size_of::<Result<bool, Infallible>>(),
-            core::mem::size_of::<bool>()
-        );
     }
 
     #[test]

--- a/src/rr/typeset.rs
+++ b/src/rr/typeset.rs
@@ -1,0 +1,410 @@
+use core::any::TypeId;
+use core::convert::Infallible;
+use core::marker::PhantomData;
+
+pub trait TypeSet {
+    type Error;
+
+    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error>;
+
+    #[inline]
+    fn contains_type_checked<T: 'static + ?Sized>(&self) -> Result<bool, Self::Error>
+    where
+        Self: Sized,
+    {
+        self.contains_id_checked(TypeId::of::<T>())
+    }
+    #[allow(unused_variables)]
+    #[inline]
+    fn contains_type_of_checked<T: 'static + ?Sized>(&self, value: &T) -> Result<bool, Self::Error>
+    where
+        Self: Sized,
+    {
+        self.contains_type_checked::<T>()
+    }
+
+    #[inline]
+    fn contains_id(&self, type_id: TypeId) -> bool
+    where
+        Self: TypeSet<Error = Infallible> + Sized,
+    {
+        match self.contains_id_checked(type_id) {
+            Ok(result) => result,
+            Err(never) => match never {},
+        }
+    }
+    #[inline]
+    fn contains_type<T: 'static + ?Sized>(&self) -> bool
+    where
+        Self: TypeSet<Error = Infallible> + Sized,
+    {
+        match self.contains_type_checked::<T>() {
+            Ok(result) => result,
+            Err(never) => match never {},
+        }
+    }
+    #[allow(unused_variables)]
+    #[inline]
+    fn contains_type_of<T: 'static + ?Sized>(&self, value: &T) -> bool
+    where
+        Self: TypeSet<Error = Infallible> + Sized,
+    {
+        match self.contains_type_of_checked::<T>(value) {
+            Ok(result) => result,
+            Err(never) => match never {},
+        }
+    }
+}
+
+// impl<E> TypeSet for &dyn TypeSet<Error = E> {
+//     type Error = E;
+//     #[inline]
+//     fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
+//         (**self).contains_id_checked(type_id)
+//     }
+// }
+
+// impl<E> TypeSet for Box<dyn TypeSet<Error = E>> {
+//     type Error = E;
+//     #[inline]
+//     fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
+//         (**self).contains_id_checked(type_id)
+//     }
+// }
+
+#[derive(Debug)]
+pub struct Only<T: ?Sized>(PhantomData<T>);
+
+impl<T: ?Sized> Default for Only<T> {
+    #[inline]
+    fn default() -> Self {
+        Only(PhantomData)
+    }
+}
+
+impl<T> TypeSet for Only<T>
+where
+    T: 'static + ?Sized,
+{
+    type Error = Infallible;
+    #[inline]
+    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
+        Ok(type_id == TypeId::of::<T>())
+    }
+}
+
+// impl<const N: usize> TypeSet for [TypeId; N] {
+//     type Error = Infallible;
+//     #[inline]
+//     fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
+//         Ok(self.contains(&type_id))
+//     }
+// }
+
+// impl TypeSet for Vec<TypeId> {
+//     type Error = Infallible;
+//     #[inline]
+//     fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
+//         Ok(self.contains(&type_id))
+//     }
+// }
+
+// impl TypeSet for [TypeId] {
+//     type Error = Infallible;
+//     #[inline]
+//     fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
+//         Ok(self.contains(&type_id))
+//     }
+// }
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct All;
+
+impl TypeSet for All {
+    type Error = Infallible;
+    #[inline]
+    fn contains_id_checked(&self, _type_id: TypeId) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AnyOf<T: ?Sized>(PhantomData<T>);
+
+impl<T: ?Sized> Default for AnyOf<T> {
+    #[inline]
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T1> TypeSet for AnyOf<(T1,)>
+where
+    T1: 'static + ?Sized,
+{
+    type Error = Infallible;
+    #[inline]
+    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
+        Ok(type_id == TypeId::of::<T1>())
+    }
+}
+
+impl<T1, T2> TypeSet for AnyOf<(T1, T2)>
+where
+    T1: 'static,
+    T2: 'static,
+{
+    type Error = Infallible;
+    #[inline]
+    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
+        Ok(type_id == TypeId::of::<T1>() || type_id == TypeId::of::<T2>())
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6> TypeSet for AnyOf<(T1, T2, T3, T4, T5, T6)>
+where
+    T1: 'static,
+    T2: 'static,
+    T3: 'static,
+    T4: 'static,
+    T5: 'static,
+    T6: 'static,
+{
+    type Error = Infallible;
+    #[inline]
+    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
+        Ok(type_id == TypeId::of::<T1>()
+            || type_id == TypeId::of::<T2>()
+            || type_id == TypeId::of::<T3>()
+            || type_id == TypeId::of::<T4>()
+            || type_id == TypeId::of::<T5>()
+            || type_id == TypeId::of::<T6>())
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> TypeSet
+    for AnyOf<(
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+    )>
+where
+    T1: 'static,
+    T2: 'static,
+    T3: 'static,
+    T4: 'static,
+    T5: 'static,
+    T6: 'static,
+    T7: 'static,
+    T8: 'static,
+    T9: 'static,
+    T10: 'static,
+    T11: 'static,
+    T12: 'static,
+    T13: 'static,
+    T14: 'static,
+    T15: 'static,
+    T16: 'static,
+{
+    type Error = Infallible;
+    #[inline]
+    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
+        Ok(type_id == TypeId::of::<T1>()
+            || type_id == TypeId::of::<T2>()
+            || type_id == TypeId::of::<T3>()
+            || type_id == TypeId::of::<T4>()
+            || type_id == TypeId::of::<T5>()
+            || type_id == TypeId::of::<T6>()
+            || type_id == TypeId::of::<T7>()
+            || type_id == TypeId::of::<T8>()
+            || type_id == TypeId::of::<T9>()
+            || type_id == TypeId::of::<T10>()
+            || type_id == TypeId::of::<T11>()
+            || type_id == TypeId::of::<T12>()
+            || type_id == TypeId::of::<T13>()
+            || type_id == TypeId::of::<T14>()
+            || type_id == TypeId::of::<T15>()
+            || type_id == TypeId::of::<T16>())
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct And<T: TypeSet, U: TypeSet>(pub T, pub U);
+
+impl<T, U> TypeSet for And<T, U>
+where
+    T: TypeSet<Error = Infallible>,
+    U: TypeSet<Error = Infallible>,
+{
+    type Error = Infallible;
+    #[inline]
+    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
+        Ok(self.0.contains_id(type_id) && self.1.contains_id(type_id))
+    }
+    #[inline]
+    fn contains_type_checked<Typ: 'static + ?Sized>(&self) -> Result<bool, Self::Error> {
+        Ok(self.0.contains_type::<Typ>() && self.1.contains_type::<Typ>())
+    }
+    #[inline]
+    fn contains_type_of_checked<Typ: 'static + ?Sized>(
+        &self,
+        val: &Typ,
+    ) -> Result<bool, Self::Error> {
+        Ok(self.0.contains_type_of(val) && self.1.contains_type_of(val))
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Or<T: TypeSet, U: TypeSet>(pub T, pub U);
+
+impl<T, U> TypeSet for Or<T, U>
+where
+    T: TypeSet<Error = Infallible>,
+    U: TypeSet<Error = Infallible>,
+{
+    type Error = Infallible;
+    #[inline]
+    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
+        Ok(self.0.contains_id(type_id) || self.1.contains_id(type_id))
+    }
+    #[inline]
+    fn contains_type_checked<Typ: 'static + ?Sized>(&self) -> Result<bool, Self::Error> {
+        Ok(self.0.contains_type::<Typ>() || self.1.contains_type::<Typ>())
+    }
+    #[inline]
+    fn contains_type_of_checked<Typ: 'static + ?Sized>(
+        &self,
+        val: &Typ,
+    ) -> Result<bool, Self::Error> {
+        Ok(self.0.contains_type_of(val) || self.1.contains_type_of(val))
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Not<T: TypeSet>(pub T);
+
+impl<T: TypeSet> TypeSet for Not<T> {
+    type Error = T::Error;
+    #[inline]
+    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
+        self.0.contains_id_checked(type_id).map(|result| !result)
+    }
+    #[inline]
+    fn contains_type_checked<Typ: 'static + ?Sized>(&self) -> Result<bool, Self::Error> {
+        self.0.contains_type_checked::<Typ>().map(|result| !result)
+    }
+    #[inline]
+    fn contains_type_of_checked<Typ: 'static + ?Sized>(
+        &self,
+        val: &Typ,
+    ) -> Result<bool, Self::Error> {
+        self.0.contains_type_of_checked(val).map(|result| !result)
+    }
+}
+
+pub type StringLike = AnyOf<(String, &'static str)>;
+
+pub type BytesLike = AnyOf<(Vec<u8>, &'static [u8])>;
+
+#[derive(Debug)]
+pub struct AcceptedBy<R>(PhantomData<R>);
+
+impl<R> AcceptedBy<R> {
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<R> Default for AcceptedBy<R> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<R: super::Receiver> TypeSet for AcceptedBy<R> {
+    type Error = Infallible;
+    #[inline]
+    fn contains_id_checked(&self, type_id: TypeId) -> Result<bool, Self::Error> {
+        Ok(R::accepting()
+            .contains_id_checked(type_id)
+            .unwrap_or_default())
+    }
+    #[inline]
+    fn contains_type_checked<T: 'static + ?Sized>(&self) -> Result<bool, Self::Error> {
+        Ok(R::accepting()
+            .contains_type_checked::<T>()
+            .unwrap_or_default())
+    }
+    #[inline]
+    fn contains_type_of_checked<T: 'static + ?Sized>(
+        &self,
+        value: &T,
+    ) -> Result<bool, Self::Error> {
+        Ok(R::accepting()
+            .contains_type_of_checked(value)
+            .unwrap_or_default())
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Invalid<E>(E);
+
+impl<E: Clone> TypeSet for Invalid<E> {
+    type Error = E;
+    #[inline]
+    fn contains_id_checked(&self, _type_id: TypeId) -> Result<bool, Self::Error> {
+        Err(self.0.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_only() {
+        let set = Only::<u8>::default();
+        assert!(set.contains_type::<u8>());
+        assert!(!set.contains_type::<u16>());
+    }
+
+    #[test]
+    fn infallible_result_size() {
+        assert_eq!(
+            core::mem::size_of::<Result<bool, Infallible>>(),
+            core::mem::size_of::<bool>()
+        );
+    }
+
+    #[test]
+    fn stringlike() {
+        let set = StringLike::default();
+        assert!(set.contains_type::<String>());
+        assert!(set.contains_type::<&str>());
+        assert!(!set.contains_type::<u8>());
+    }
+
+    #[test]
+    fn byteslike() {
+        let set = BytesLike::default();
+        assert!(set.contains_type::<Vec<u8>>());
+        assert!(set.contains_type::<&[u8]>());
+        assert!(!set.contains_type::<u8>());
+    }
+}

--- a/src/rr/typeset.rs
+++ b/src/rr/typeset.rs
@@ -1,5 +1,4 @@
 use core::any::TypeId;
-use core::convert::Infallible;
 use core::marker::PhantomData;
 
 pub trait TypeSet {

--- a/src/rr/typeset.rs
+++ b/src/rr/typeset.rs
@@ -229,9 +229,8 @@ impl<T: TypeSet> TypeSet for Not<T> {
     }
 }
 
-pub type StringLike = AnyOf<(String, &'static str)>;
-
-pub type BytesLike = AnyOf<(Vec<u8>, &'static [u8])>;
+pub const STRING_LIKE: AnyOf<(String, &'static str)> = AnyOf::new();
+pub const BYTES_LIKE: AnyOf<(Vec<u8>, &'static [u8])> = AnyOf::new();
 
 #[derive(Debug)]
 pub struct AcceptedBy<R>(PhantomData<R>);
@@ -279,7 +278,7 @@ mod tests {
 
     #[test]
     fn stringlike() {
-        let set = StringLike::default();
+        let set = STRING_LIKE;
         assert!(set.contains_type::<String>());
         assert!(set.contains_type::<&str>());
         assert!(!set.contains_type::<u8>());
@@ -287,7 +286,7 @@ mod tests {
 
     #[test]
     fn byteslike() {
-        let set = BytesLike::default();
+        let set = BYTES_LIKE;
         assert!(set.contains_type::<Vec<u8>>());
         assert!(set.contains_type::<&[u8]>());
         assert!(!set.contains_type::<u8>());


### PR DESCRIPTION
* Rename Req to Query
* Split Query into own mod
* New mod: typeset
* Use Erased instead of Unknown as default
* Return TypeSet instead of checking single type in receiver
* Export rr::meta::META_TYPES constant
* Export rr::typeset::{STRING_LIKE, BYTES_LIKE} constants